### PR TITLE
don't render 0-width lines to PDF

### DIFF
--- a/exec-src/rastertest.hs
+++ b/exec-src/rastertest.hs
@@ -352,6 +352,19 @@ strokeTest stroker texture prefix =
                    logo 100 False $ V2 240 240]
           ]
 
+strokeWidthTest :: (forall g. Stroker g)
+                -> IO ()
+strokeWidthTest stroker =
+    produceImageAtSize 500 500 "stroke_width.png"
+        $ withTexture (uniformTexture black)
+        $ drawing
+  where
+    drawing = sequence_ $
+          [ stroker w JoinRound (CapRound, CapRound) l
+          | (w, l) <- zip [0..] ls ]
+    ls = [ lineFromPath [ V2 50 (50 * i), V2 450 (50 * i) ]
+         | i <- [1..9] ]
+
 orientationAxisText :: IO ()
 orientationAxisText =
     let trans = translate (V2 200 200) <> toNewXBase (V2 1 (-0.5)) in
@@ -734,6 +747,7 @@ testSuite = do
   strokeTest stroke bigBiGradient "gradient_"
   strokeTest stroke radTriGradient "rad_gradient_"
   strokeLogo stroke ""
+  strokeWidthTest stroke
 
   strokeQuadraticIntersection stroke uniform ""
   strokeQuadraticIntersection stroke triGradient "gradient_"

--- a/src/Graphics/Rasterific/MicroPdf.hs
+++ b/src/Graphics/Rasterific/MicroPdf.hs
@@ -1034,15 +1034,18 @@ pdfProducer baseTexture draw = do
        pure $ foldMap pathToPdf (resplit prims)
             <> filler method
             <> after
+
      Stroke w j (c, _) prims next -> do
        after <- recurse next
        let output p = pathToPdf p <> reClose p
-       pure $ toPdf w <> tp " w "
-            <> lineJoinOf j
-            <> lineCapOf  c <> "\n"
-            <> foldMap output (resplit prims)
-            <> tp "S\n"
-            <> after
+           stroke = case w of
+             0 -> mempty
+             _ -> toPdf w <> tp " w "
+                          <> lineJoinOf j
+                          <> lineCapOf  c <> "\n"
+                          <> foldMap output (resplit prims)
+                          <> tp "S\n"
+       pure $ stroke <> after
      
      DashedStroke o pat w j (c, _) prims next -> do
        sub <- go forceInverse activeTrans filler prevTexture $ Stroke w j (c, c) prims (Pure ())


### PR DESCRIPTION
This adds a test that shows that currently a 0-width line ends up in the PDF but not in the PNG.

This may depend on the PDF viewer, compare https://tex.stackexchange.com/questions/210125/tikz-zero-width-line-with-dashed-line. Width 0 is "1 device pixel" by spec.

And adds a change to omit width-0 lines from the PDF. (This seems to do just that, but I'm not really that sure of how the code in question works and whether something goes missing now.)