### PR TITLE
Render multiple pdf pages

### DIFF
--- a/src/Graphics/Rasterific.hs
+++ b/src/Graphics/Rasterific.hs
@@ -68,6 +68,7 @@ module Graphics.Rasterific
     , renderDrawing
     , renderDrawingAtDpi
     , renderDrawingAtDpiToPDF
+    , renderDrawingsAtDpiToPDF
     , renderOrdersAtDpiToPdf 
     , pathToPrimitives
 
@@ -439,8 +440,16 @@ renderDrawingAtDpiToPDF
     -> Dpi -- ^ Current DPI used for text rendering.
     -> Drawing PixelRGBA8 () -- ^ Rendering action
     -> LB.ByteString
-renderDrawingAtDpiToPDF w h dpi =
-  renderDrawingToPdf renderer w h dpi
+renderDrawingAtDpiToPDF w h dpi d = renderDrawingsAtDpiToPDF w h dpi [d]
+
+renderDrawingsAtDpiToPDF
+    :: Int -- ^ Rendering width
+    -> Int -- ^ Rendering height
+    -> Dpi -- ^ Current DPI used for text rendering.
+    -> [Drawing PixelRGBA8 ()] -- ^ Rendering actions
+    -> LB.ByteString
+renderDrawingsAtDpiToPDF w h dpi =
+  renderDrawingsToPdf renderer w h dpi
     where
       renderer :: forall px . RenderablePixel px => Drawing px () -> [DrawOrder px]
       renderer = drawOrdersOfDrawing w h dpi emptyPx

--- a/src/Graphics/Rasterific/MicroPdf.hs
+++ b/src/Graphics/Rasterific/MicroPdf.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TupleSections #-}
 module Graphics.Rasterific.MicroPdf( renderDrawingToPdf
+                                   , renderDrawingsToPdf
                                    , renderOrdersToPdf
                                    ) where
 
@@ -377,7 +378,7 @@ pdfSignature :: B.ByteString
 pdfSignature = "%PDF-1.4\n%\xBF\xF7\xA2\xFE\n"
 
 refOf :: PdfId -> B.ByteString
-refOf i = buildToStrict $ intDec i <> " 0 R"
+refOf i = buildToStrict $ intDec i <> " 0 R "
 
 arrayOf :: Builder -> Builder
 arrayOf a = tp "[ " <> a <> tp " ]"
@@ -1009,8 +1010,13 @@ pdfFromProducers px conf producers = toLazyByteString $
 renderDrawingToPdf :: (forall px . PdfColorable px => Drawing px () -> [DrawOrder px])
                    -> Int -> Int -> Dpi -> Drawing PixelRGBA8 ()
                    -> LB.ByteString
-renderDrawingToPdf toOrders width height dpi =
-    pdfFromProducer px conf . pdfProducer baseTexture
+renderDrawingToPdf toOrders width height dpi d = renderDrawingsToPdf toOrders width height dpi [d]
+
+renderDrawingsToPdf :: (forall px . PdfColorable px => Drawing px () -> [DrawOrder px])
+                   -> Int -> Int -> Dpi -> [Drawing PixelRGBA8 ()]
+                   -> LB.ByteString
+renderDrawingsToPdf toOrders width height dpi ds =
+    pdfFromProducers px conf $ map (pdfProducer baseTexture) ds
   where
     px = Proxy :: Proxy PixelRGBA8
     baseTexture = SolidTexture emptyPx 


### PR DESCRIPTION
This implements #46. It adds the function `renderDrawingsAtDpiToPDF` that will render a list of drawings to different pdf pages. I don't really know much about the pdf file format, but this seems to work for me. 

Things could probably be refactored so that each page can have different widths and heights. `runPdfEnv` and its dependencies should probably be removed too. 